### PR TITLE
Calculate reconstructed slice position

### DIFF
--- a/mrrecon/data/writer.py
+++ b/mrrecon/data/writer.py
@@ -96,8 +96,7 @@ def invert_velocity(v, dcm_img_max=4096):
     return v
 
 
-def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True,
-                         slices_to_include=None):
+def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True):
     """Writes 4D flow dicoms.
 
     Dicoms work for the 4D flow module in cvi42.
@@ -111,8 +110,6 @@ def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True,
         outdir (str): Folder where dicoms will be saved.
         save_as_unique_study (bool): Use this to make dicoms appear in their
             own study in the study list in cvi42.
-        slices_to_include (array): 1D array of integers indicating which slices
-            should be written to dicoms.
     """
     assert img.ndim == 5, f'5D array required. Got {img.ndim}D array instead.'
     nv, nt, nz, ny, nx = img.shape
@@ -276,9 +273,6 @@ def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True,
         imPos_edge = (imPos - fovy / 2 * R[:, 0] + fovx / 2 * R[:, 1]
                       - fovz / 2 * np.array([Sag_inc, Cor_inc, Tra_inc]))
 
-        if slices_to_include is None:
-            slices_to_include = np.arange(nz)
-
         frame_array = np.arange(0, ds.NominalInterval, ds.NominalInterval / nt)
 
         for iframe in range(nt):
@@ -286,7 +280,7 @@ def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True,
             ds.InstanceCreationTime = str(startTime + frame_array[iframe]/1000)
             ds.ContentTime = str(startTime + frame_array[iframe]/1000)
 
-            for islice in slices_to_include:
+            for islice in range(nz):
                 imPos_slice = imPos_edge + dz * islice * np.array([Sag_inc, Cor_inc, Tra_inc])
                 ds.SliceLocation = imPos_slice[-1]
                 ds.ImagePositionPatient = np.ravel(imPos_slice).tolist()

--- a/mrrecon/data/writer.py
+++ b/mrrecon/data/writer.py
@@ -341,8 +341,8 @@ def crop(img, img_pos, x_inds=None, y_inds=None, z_inds=None,
     Args:
         img (array): Array with shape (..., nz, ny, nx).
         img_pos (array): Array with shape (3,). Position of the centre voxel in
-            mm. Formatting should be the same as the slice position parameter
-            from the Siemens twix data header.
+            mm. Coordinate system should be the same as the slice position
+            parameter from the Siemens twix data header.
         x_inds (tuple): 2-tuple containing indices to slice the input in x.
         y_inds (tuple): 2-tuple containing indices to slice the input in y.
         z_inds (tuple): 2-tuple containing indices to slice the input in z.

--- a/mrrecon/data/writer.py
+++ b/mrrecon/data/writer.py
@@ -52,6 +52,9 @@ def _fix_matfile_format(d):
     d['fovx_prescribed'] = d['fovx_prescribed'].item()
     d['fovy_prescribed'] = d['fovy_prescribed'].item()
     d['fovz_prescribed'] = d['fovz_prescribed'].item()
+    d['fovx_shift'] = d['fovx_shift'].item()
+    d['fovy_shift'] = d['fovy_shift'].item()
+    d['fovz_shift'] = d['fovz_shift'].item()
     d['rr_avg'] = d['rr_avg'].item()
     d['systemmodel'] = str(d['systemmodel'][0])
     d['acquisition_date'] = str(d['acquisition_date'][0])
@@ -69,6 +72,7 @@ def _fix_matfile_format(d):
     d['slice_pos'] = np.array([d['slice_pos']['flSag'].item().item(),
                                d['slice_pos']['flCor'].item().item(),
                                d['slice_pos']['flTra'].item().item()])
+    d['recon_pos'] = d['recon_pos'][0]
 
     d['rot_quat'] = d['rot_quat'][0]
 

--- a/mrrecon/data/writer.py
+++ b/mrrecon/data/writer.py
@@ -272,7 +272,7 @@ def write_4d_flow_dicoms(img, data, outdir, save_as_unique_study=True):
             Cor_inc = data['slice_normal']['dCor']
             ds.ImageOrientationPatient[:] = [1, 0, 0, 0, 0, 1]
 
-        imPos = np.array(data['slice_pos'].tolist())
+        imPos = data['recon_pos']
 
         imPos_edge = (imPos - fovy / 2 * R[:, 0] + fovx / 2 * R[:, 1]
                       - fovz / 2 * np.array([Sag_inc, Cor_inc, Tra_inc]))


### PR DESCRIPTION
The slice position should now be written correctly into dicoms, taking into consideration shifted FOV recons, and off-centre image cropping. Slice position may still be off by ~1 pixel due to poorly defined/unknown definitions used by Siemens/dicom.

Instead of using the `slice_pos` parameter from the twix data header, a new variable `recon_pos` is now used, which copies `slice_pos` but also is adjusted by reconstructed FOV shifts.

The new function `mr.data.writer.crop` should be used to help crop the image after reconstruction. It crops the image but also calculates the new position of the centre pixel.

The slice position is important for cvi42 when matching 4D flow images with 2D phase contrast images. Errors in matching could still exist because of gradient delays (which approximately stretch the image) or motion.